### PR TITLE
Update Worker.py

### DIFF
--- a/Worker.py
+++ b/Worker.py
@@ -130,11 +130,14 @@ class StartWorker(Worker):
                     result = self.instance.modify_attribute(
                         InstanceType={
                             'Value': modifiedInstanceType
-                        },
+                        }
+                    )
+                    result = self.instance.modify_attribute(
                         EbsOptimized={
                             'Value': ebsOptimizedAttr
                         }
                     )
+                        
                     # It appears the start instance reads 'modify_attribute' changes as eventually consistent in AWS (assume DynamoDB),
                     #    this can cause an issue on instance type change, whereby the LaunchPlan generates an exception.
                     #    To mitigate against this, we will introduce a one second sleep delay after modifying an attribute


### PR DESCRIPTION
Currently there is an issue when changing instance type and modifying EBS optimized flag, as instance can modify only one attribute per call.

Documentation:

http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Instance.modify_attribute

"Modifies the specified attribute of the specified instance. You can specify only one attribute at a time."

Proposed change is to separate those two calls.