### PR TITLE
Add sleep between ModifyInstances calls and check each of them

### DIFF
--- a/Worker.py
+++ b/Worker.py
@@ -127,17 +127,26 @@ class StartWorker(Worker):
                     else:
                         ebsOptimizedAttr = self.instance.ebs_optimized    # May have been set to True or False previously
 
-                    result = self.instance.modify_attribute(
-                        InstanceType={
-                            'Value': modifiedInstanceType
-                        }
-                    )
-                    result = self.instance.modify_attribute(
-                        EbsOptimized={
-                            'Value': ebsOptimizedAttr
-                        }
-                    )
-                        
+		    try:
+
+	                    result = self.instance.modify_attribute(
+        	                InstanceType={
+                	            'Value': modifiedInstanceType
+                        	}
+                    	)
+		    except Exception as e:
+		    	    self.logger.warning('Worker:instance.modify_attribute() encountered an exception where requested instance type ['+ modifiedInstanceType +'] resulted in -->' + str(e))
+		    
+		    time.sleep(self.scalingInstanceDelay)
+		    try: 
+			
+                    	result = self.instance.modify_attribute(
+                        	EbsOptimized={
+                            	'Value': ebsOptimizedAttr
+                        	}
+                    	)
+                    except Exception as e:
+			    self.logger.warning('Worker:instance.modify_attribute() encountered an exception where requested instance type ['+ modifiedInstanceType +'] resulted in -->' + str(e))
                     # It appears the start instance reads 'modify_attribute' changes as eventually consistent in AWS (assume DynamoDB),
                     #    this can cause an issue on instance type change, whereby the LaunchPlan generates an exception.
                     #    To mitigate against this, we will introduce a one second sleep delay after modifying an attribute

--- a/Worker.py
+++ b/Worker.py
@@ -128,25 +128,22 @@ class StartWorker(Worker):
                         ebsOptimizedAttr = self.instance.ebs_optimized    # May have been set to True or False previously
 
 		    try:
-
+			    operation = 'InstanceType'
 	                    result = self.instance.modify_attribute(
         	                InstanceType={
                 	            'Value': modifiedInstanceType
                         	}
                     	)
-		    except Exception as e:
-		    	    self.logger.warning('Worker:instance.modify_attribute() encountered an exception where requested instance type ['+ modifiedInstanceType +'] resulted in -->' + str(e))
 		    
-		    time.sleep(self.scalingInstanceDelay)
-		    try: 
-			
-                    	result = self.instance.modify_attribute(
+		    	    time.sleep(self.scalingInstanceDelay)
+			    operation = 'ChangeEBSOptimization'
+                       	    result = self.instance.modify_attribute(
                         	EbsOptimized={
                             	'Value': ebsOptimizedAttr
                         	}
                     	)
                     except Exception as e:
-			    self.logger.warning('Worker:instance.modify_attribute() encountered an exception where requested instance type ['+ modifiedInstanceType +'] resulted in -->' + str(e))
+			    self.logger.warning('Worker:instance.modify_attribute() encountered an exception where requested instance type ['+ operation +'] resulted in -->' + str(e))
                     # It appears the start instance reads 'modify_attribute' changes as eventually consistent in AWS (assume DynamoDB),
                     #    this can cause an issue on instance type change, whereby the LaunchPlan generates an exception.
                     #    To mitigate against this, we will introduce a one second sleep delay after modifying an attribute


### PR DESCRIPTION
This change is to allow time.sleep between each instance.modify_attribute call and to perform checks for each of them. Otherwise, we may encounter throttling.