### PR TITLE
T2 unlimited separate method

### DIFF
--- a/Orchestrator.py
+++ b/Orchestrator.py
@@ -212,6 +212,12 @@ class Orchestrator(object):
 			msg = 'Orchestrator::__init__() Exception obtaining botot3 elb client in region %s -->' % self.workloadRegion
 			logger.error(msg + str(e))
 
+		try:
+			self.ec2_client = boto3.client('ec2',region_name=self.workloadRegion)
+	 	except Exception as e:
+			msg = 'Orchestrator::__init__() Exception obtaining boto3 ec2 client in region %s -->' % self.workloadRegion
+			logger.error(msg + str(e))
+
 		# Grab tier specific workload information from DynamoDB
                 self.lookupTierSpecs(self.partitionTargetValue)
 
@@ -596,7 +602,7 @@ class Orchestrator(object):
 
 
 		for currInstance in instancesToStopList:
-			stopWorker = StopWorker(self.dynamoDBRegion, self.workloadRegion, currInstance, self.dryRunFlag,self.max_api_request,self.snsInit)
+			stopWorker = StopWorker(self.dynamoDBRegion, self.workloadRegion, currInstance, self.dryRunFlag,self.max_api_request,self.snsInit,self.ec2_client)
 			stopWorker.setWaitFlag(tierSynchronized)
 			stopWorker.execute(
 				self.workloadSpecificationDict[Orchestrator.WORKLOAD_SSM_S3_BUCKET_NAME],
@@ -639,7 +645,7 @@ class Orchestrator(object):
 
 		for currInstance in instancesToStartList:
 			logger.debug('Starting instance %s', currInstance)
-			startWorker = StartWorker(self.dynamoDBRegion, self.workloadRegion, currInstance, self.all_elbs, self.elb, self.scaleInstanceDelay, self.dryRunFlag, self.max_api_request,self.snsInit)
+			startWorker = StartWorker(self.dynamoDBRegion, self.workloadRegion, currInstance, self.all_elbs, self.elb, self.scaleInstanceDelay, self.dryRunFlag, self.max_api_request,self.snsInit,self.ec2_client)
 
 			# If a ScalingProfile was specified, change the instance type now, prior to Start
 			instanceTypeToLaunch = self.isScalingAction(tierName)

--- a/Worker.py
+++ b/Worker.py
@@ -187,18 +187,14 @@ class StartWorker(Worker):
 
     def t2Unlimited(self,modifiedInstanceList):
 	
-	current_t2_value = self.ec2_client.describe_instance_credit_specifications(
-		InstanceIds=[
-	        self.instance.id,
-        	     ]
-	        )['InstanceCreditSpecifications'][0]['CpuCredits']
 	if len(modifiedInstanceList) == 3:
 		self.modifiedInstanceFlag = modifiedInstanceList[2]
 		logger.info('t2Unlimited(): Checking if T2 Unlimited flag is specified in DynamoDB')
 		logger.debug('t2Unlimited(): t2_unlimited_flag: %s' % self.modifiedInstanceFlag )
 		if ( self.modifiedInstanceFlag == "u") or ( self.modifiedInstanceFlag == "U"):
 		    logger.debug('t2Unlimited(): Found T2 Flag in DynamoDB: %s' % self.modifiedInstanceFlag )
-		    if current_t2_value == "standard":
+		    self.check_t2_unlimited()
+		    if self.current_t2_value == "standard":
 			t2_unlimited_done=0
 			t2_unlimited_retry_count=1
 			while(t2_unlimited_done == 0):
@@ -221,8 +217,9 @@ class StartWorker(Worker):
 				self.snsInit.exponentialBackoff(t2_unlimited_retry_count,msg,subject_prefix)
 				t2_unlimited_retry_count += 1
 	else:
-		if current_t2_value == "unlimited":
-	        	logger.debug('t2Unlimited(): Current T2 value: %s' % current_t2_value)
+		self.check_t2_unlimited()
+		if self.current_t2_value == "unlimited":
+	        	logger.debug('t2Unlimited(): Current T2 value: %s' % self.current_t2_value)
 			t2_standard_done=0
 	      		t2_standard_retry_count=1
 			while(t2_standard_done == 0):
@@ -244,6 +241,25 @@ class StartWorker(Worker):
 				subject_prefix = "Exception EC2 T2 unlimited"
 				self.snsInit.exponentialBackoff(t2_standard_retry_count,msg,subject_prefix)
 				t2_standard_retry_count += 1
+    def check_t2_unlimited(self):
+	t2_standard_check_done=0
+	t2_standard_check_retry_count=1
+	while(t2_standard_check_done == 0):
+	    try:
+		logger.info('check_t2_unlimited(): Checking current T2 value')
+		self.current_t2_value = self.ec2_client.describe_instance_credit_specifications(
+                InstanceIds=[
+                self.instance.id,
+                     ]
+                )['InstanceCreditSpecifications'][0]['CpuCredits']
+		t2_standard_check_done=1
+	    except Exception as e:
+		msg = 'Worker::describe_instance_credit_specifications() Exponential Backoff in progress for EC2 instance %s, retry count = %s, error --> %s' % (self.instance,t2_standard_check_retry_count,str(e))
+		logger.warning(msg)
+		subject_prefix = "Exception EC2 T2 unlimited"
+		self.snsInit.exponentialBackoff(t2_standard_check_retry_count,msg,subject_prefix)
+		t2_standard_check_retry_count += 1
+	return self.current_t2_value
 
     def start(self):
         self.startInstance()


### PR DESCRIPTION
We were calling ec2_client.describe_instance_credit_specifications API whenever "-p" flag was specified and we were not checking it for throttling.

This PR is proposing to separate that API call into separated method checkT2Unlimited() and call it when needed, and also ensures that we are using Backoff on it.