### PR TITLE
Feature/ARCH-10118 - IgnoreStop Action on Tier

### DIFF
--- a/Orchestrator.py
+++ b/Orchestrator.py
@@ -570,7 +570,7 @@ class Orchestrator(object):
 				self.sequenceTiers(Orchestrator.TIER_STOP)
 
 				for currTier in self.sequencedTiersList:
-					logger.info("IgnoreStopValue for {} tier is {}".format(currTier, self.tierSpecDict[currTier][Orchestrator.TIER_STOP][Orchestrator.TIER_IGNORE_STOP]))
+					logger.debug("IgnoreStopValue for {} tier is {}".format(currTier, self.tierSpecDict[currTier][Orchestrator.TIER_STOP][Orchestrator.TIER_IGNORE_STOP]))
 					if 	self.tierSpecDict[currTier][Orchestrator.TIER_STOP][Orchestrator.TIER_IGNORE_STOP] =='True':
 						logger.info('Orchestrate() IgnoreStop set to True for Tier {} so no stop action was performed'.format(currTier))
 						continue # if condition above is met continue to next tier, do not execute stop on current tier.

--- a/Orchestrator.py
+++ b/Orchestrator.py
@@ -71,7 +71,7 @@ class Orchestrator(object):
 	TIER_SYCHRONIZATION='TierSynchronization'
 	TIER_STOP_OVERRIDE_FILENAME='TierStopOverrideFilename'
 	TIER_STOP_OS_TYPE='TierStopOverrideOperatingSystem' # Valid values are Linux and Windows
-
+	TIER_IGNORE_STOP = 'IgnoreStop'
 	INTER_TIER_ORCHESTRATION_DELAY='InterTierOrchestrationDelay' # The sleep time between commencing an action on this tier
 	INTER_TIER_ORCHESTRATION_DELAY_DEFAULT = 5
 
@@ -159,7 +159,8 @@ class Orchestrator(object):
 			Orchestrator.TIER_SYCHRONIZATION,
 			Orchestrator.TIER_STOP_OVERRIDE_FILENAME,
 			Orchestrator.TIER_STOP_OS_TYPE,
-			Orchestrator.INTER_TIER_ORCHESTRATION_DELAY
+			Orchestrator.INTER_TIER_ORCHESTRATION_DELAY,
+			Orchestrator.TIER_IGNORE_STOP
 		]
 
 		self.scalingProfile = scalingProfile
@@ -569,9 +570,11 @@ class Orchestrator(object):
 				self.sequenceTiers(Orchestrator.TIER_STOP)
 
 				for currTier in self.sequencedTiersList:
-				
+					logger.info("IgnoreStopValue for {} tier is {}".format(currTier, self.tierSpecDict[currTier][Orchestrator.TIER_STOP][Orchestrator.TIER_IGNORE_STOP]))
+					if 	self.tierSpecDict[currTier][Orchestrator.TIER_STOP][Orchestrator.TIER_IGNORE_STOP] =='True':
+						logger.info('Orchestrate() IgnoreStop set to True for Tier {} so no stop action was performed'.format(currTier))
+						continue # if condition above is met continue to next tier, do not execute stop on current tier.
 					logger.info('Orchestrate() Stopping Tier: ' + currTier)
-				
 					# Stop the next tier in the sequence
 					self.stopATier(currTier)
 	

--- a/README.md
+++ b/README.md
@@ -460,6 +460,9 @@ Here are a few things you **need** to know about the Tier Specification:
 |**InterTierOrchestrationDelay**|The number of seconds to delay before actioning on the next tier.  Typically, you have a sense for how long to wait after the current tier starts or stops before actioning on the next tier.  This is where you set that delay, in seconds.  *Note: This is a string value* |No (default value is 5 seconds)|
 |**TierStopOverrideFilename**|The name of the override file in the guest OS to check for existance.  If the file exists in the guest OS, the server will not be stopped.|No|
 |**TierStopOverrideOperatingSystem**|The name of the OS in the guest.  Valid values are "Linux", or "Windows"|No. Unless you configure *TierStopOverrideFilename*|
+|**IgnoreStop**|Option to Ignore the Stop Command issued to the workload on a per tier basis. Valid values are True or False|
+
+
 
 #### JSON: TierSpecification Example
 The below JSON is a row in the TierSpecification DynamoDB table, and can be mapped several DynamoDB Attributes, three of which will contain JSON.  This tier, named *Role_Web* is Started as the third tier (sequence == 2) when the workload starts and is Stopped first.  Every instance is checked prior to Stopping (because Instance Exemption was configured and SSM enabled by the Administrator) to determine a file named StopOverride exists in the tmp directory (content of file is irrelevant), and if so the instance will not be stopped.  In the event of a Scaling request, with a provided profile name of "profileC", all instances within this tier will first be changed to t2.large prior to Starting.  Not all attributes are required.


### PR DESCRIPTION
New Functionality to check for the presence of a IgnoreStop key attribute in the Tier Specification table.
If the value is set to "True", the tier will not be stopped.

Example from Dynamo.

  "TierStop": {
    "IgnoreStop": "True",
    "InterTierOrchestrationDelay": 15,
    "TierSequence": 10,
    "TierSynchronization": "False"
  },